### PR TITLE
resolved #19: escape emojis with backslash

### DIFF
--- a/emoji.h
+++ b/emoji.h
@@ -1052,13 +1052,13 @@ namespace emojicpp {
         {":zipper__mouth_face:" , u8"\U0001F910"}
     };  
 
-    std::string emojize(std::string s) {
+    std::string emojize(std::string s, bool escape=true) {
         int index = -1;
         int sLen = s.size();
         for (int i = 0; i < sLen; i++) {
             if (s[i] == *L":") {
                 // check if colon is escaped
-                if(i!=0 && s[i-1]=='\\')
+                if(escape && i!=0 && s[i-1]=='\\')
                     continue;
                 if (index == -1) {
                     index = i;

--- a/emoji.h
+++ b/emoji.h
@@ -1057,6 +1057,9 @@ namespace emojicpp {
         int sLen = s.size();
         for (int i = 0; i < sLen; i++) {
             if (s[i] == *L":") {
+                // check if colon is escaped
+                if(i!=0 && s[i-1]=='\\')
+                    continue;
                 if (index == -1) {
                     index = i;
                 }


### PR DESCRIPTION
fixes #29 

This PR allows to escape emojis with a colon:

> `:smile: and \:smile:`

is substituted to

> :smile:` and :smile:`